### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -51,7 +51,8 @@
                     android:imeOptions="actionUnspecified"
                     android:maxLines="1"
                     android:singleLine="true"
-                    android:inputType="textPassword" />
+                    android:inputType="textPassword"
+                    android:importantForAccessibility="no" />
 
             </android.support.design.widget.TextInputLayout>
 

--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -58,7 +58,8 @@
                     android:imeActionLabel="@string/action_login"
                     android:imeOptions="actionUnspecified"
                     android:maxLines="1"
-                    android:inputType="textPassword" />
+                    android:inputType="textPassword"
+                    android:importantForAccessibility="no" />
 
             </android.support.design.widget.TextInputLayout>
 
@@ -70,6 +71,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="textPassword"
+                    android:importantForAccessibility="no"
                     android:ems="10"
                     android:id="@+id/passwordCheck"
                     android:hint="@string/action_provide_password_check"


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.